### PR TITLE
Update party_service.rb to use same routes as BE

### DIFF
--- a/app/services/party_service.rb
+++ b/app/services/party_service.rb
@@ -11,7 +11,9 @@ class PartyService
   end
 
   def self.update_player_party(user_id, player_id)
-    response = conn.post("/api/v1/party/#{user_id}/players/#{player_id}")
+    response = conn.post("/api/v1/party/players/#{player_id}") do |c|
+      p.params[:user_id] = user_id
+    end
     JSON.parse(response.body, symbolize_names: true)
   end
 

--- a/app/services/party_service.rb
+++ b/app/services/party_service.rb
@@ -13,6 +13,7 @@ class PartyService
   def self.update_player_party(user_id, player_id)
     response = conn.post("/api/v1/party/players") do |c|
       c.params[:user_id] = user_id
+      c.params[:player_id] = player_id
     end
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/app/services/party_service.rb
+++ b/app/services/party_service.rb
@@ -11,7 +11,7 @@ class PartyService
   end
 
   def self.update_player_party(user_id, player_id)
-    response = conn.post("/api/v1/party/players/#{player_id}") do |c|
+    response = conn.post("/api/v1/party/players") do |c|
       c.params[:user_id] = user_id
     end
     JSON.parse(response.body, symbolize_names: true)

--- a/app/services/party_service.rb
+++ b/app/services/party_service.rb
@@ -12,7 +12,7 @@ class PartyService
 
   def self.update_player_party(user_id, player_id)
     response = conn.post("/api/v1/party/players/#{player_id}") do |c|
-      p.params[:user_id] = user_id
+      c.params[:user_id] = user_id
     end
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/app/services/player_service.rb
+++ b/app/services/player_service.rb
@@ -7,7 +7,7 @@ class PlayerService
 
   def self.get_all_players_by_name(name)
     response = conn.get("/api/v1/players") do |r|
-      r.params[:query] = name
+      r.params[:name] = name
     end
     JSON.parse(response.body, symbolize_names: true)
   end


### PR DESCRIPTION
- The PartyService had `/parties/:user_id/players` - BE needs `party/players/` with user id and player passed in the params (either through a query parameter or by using `f.params` as done in PlayerService
  - Example of successful `POST` request for `/api/v1/party/players`: 
<img width="1440" alt="Screen Shot 2022-06-08 at 10 07 08 PM" src="https://user-images.githubusercontent.com/94757433/172762351-e9be74e9-6ec3-4db4-88e2-75231224364e.png">


- The PlayerService was passing `{query: 'name'}` in params, BE needs `{name: 'name'}`
  - example of successful `GET` request for `/api/v1/players`: 
<img width="1440" alt="Screen Shot 2022-06-08 at 10 08 24 PM" src="https://user-images.githubusercontent.com/94757433/172762426-30edded7-5a42-4b5f-8c9f-7180fe7202ba.png">

  