### PR TITLE
Gem fix: added platform x86_64-linux to Gemfile.lock for heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ group :development do
 end
 
 group :test do
-  gem 'capybara'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,10 +132,16 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.5.2)
     nio4r (2.5.8)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.10)
     omniauth (2.1.0)
@@ -285,7 +291,9 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
@@ -328,4 +336,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.1.4
+   2.3.6


### PR DESCRIPTION
Heroku logs gave this error from the last deployment 
```

-----> Building on the Heroku-20 stack
-----> Using buildpack: heroku/ruby
-----> Ruby app detected
-----> Installing bundler 2.3.10
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Compiling Ruby/Rails
-----> Using Ruby version: ruby-2.7.2
-----> Installing dependencies using bundler 2.3.10
       Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
       Your Gemfile lists the gem capybara (>= 0) more than once.
       You should probably keep only one of them.
       Remove any duplicate entries and specify the gem only once.
       While it's not a problem now, it could cause errors if you change the version of one of them later.
       You are trying to install in deployment mode after changing
       your Gemfile. Run `bundle install` elsewhere and add the
       updated Gemfile.lock to version control.
       
       If this is a development machine, remove the /tmp/build_593be926/Gemfile freeze 
       by running ``.
       
       The lockfile does not have all gems needed for the current platform
       Bundler Output: Your Gemfile lists the gem capybara (>= 0) more than once.
       You should probably keep only one of them.
       Remove any duplicate entries and specify the gem only once.
       While it's not a problem now, it could cause errors if you change the version of one of them later.
       You are trying to install in deployment mode after changing
       your Gemfile. Run `bundle install` elsewhere and add the
       updated Gemfile.lock to version control.
       
       If this is a development machine, remove the /tmp/build_593be926/Gemfile freeze 
       by running ``.
       
       The lockfile does not have all gems needed for the current platform
 !
 !     Failed to install gems via Bundler.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```

Which we are familiar with in the BE. It means you need to run `bundle lock --add-platform x86_64-linux` in terminal to update the Gemfile.lock. Went ahead and did that, *should* be all we need to get that deploy to succeed
 